### PR TITLE
Improve SQL query for rate_scales_worker

### DIFF
--- a/rate_scales_worker/queries.py
+++ b/rate_scales_worker/queries.py
@@ -6,7 +6,7 @@
 
 # 3rd party:
 
-# Internal: 
+# Internal:
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -25,6 +25,8 @@ WHERE metric = :metric  -- Metric
       SELECT MAX(date)
       FROM covid19.time_series_p{date}_{area_type} AS ts
           JOIN covid19.metric_reference AS mr ON mr.id = ts.metric_id
+          JOIN covid19.area_reference   AS ar ON ar.id = ts.area_id
       WHERE metric = :metric
+        AND area_type = :area_type
     );\
 """


### PR DESCRIPTION
Trying to release with 'renamed' parquet files mixed with newly generated for the day worked until submitting 'main' file. As 'rate_scales_worker' is executed during processing 'main' file, the query for the function doesn't return any results.
The modified query is improvements to the old one and can allow processing the 'main' file without any issues (even if it won't fix that particular issue it's an improvement and, in my opinion, the query should have the changes since it was created).